### PR TITLE
Fix: fix the bug -- open file error

### DIFF
--- a/main.c
+++ b/main.c
@@ -72,6 +72,7 @@ int main( int argc, char * argv[] ) {
   // 解析配置文件
   worker_dir = getcwd( NULL, 0 ); 
   full_conf_file = ( char * )malloc( sizeof( worker_dir ) + sizeof( conf_file ) + 50 );
+  bzero(full_conf_file, sizeof( worker_dir ) + sizeof( conf_file ) + 50);
   strcat( full_conf_file, worker_dir );
   free( worker_dir );
   strcat( full_conf_file, conf_file );


### PR DESCRIPTION
问题描述：
当我启动Tiginx服务器的时候，出现了open file error的问题。
问题原因：
通过调试发现，full_conf_file这块内存里面有脏数据，所以需要先清空full_conf_file里面的数据，然后再进行字符串拼接。